### PR TITLE
Erweiterung: Eltern-Berater-Bot in Streamlit-App

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,37 +1,77 @@
 import streamlit as st
 from src.generate_explanation import generate_explanation
+from src.generate_advice import generate_parenting_advice
 
-def get_user_inputs():
-    st.title("Eltern-AI: Kindgerechte Erklärungen")
 
-    topic = st.text_input("Gib ein Thema ein:", "Was ist der Tod?")
+def explanation_tab():
+    """UI und Logik für kindgerechte Erklärungen."""
+    st.header("Kindgerechte Erklärungen")
 
-    age_group = st.selectbox("Alter des Kindes:",
-                              ["< 3 Jahre", "3–6 Jahre", "7–9 Jahre", "10–12 Jahre", "13+ Jahre"])
+    topic = st.text_input("Gib ein Thema ein:", "Was ist der Tod?", key="topic")
+    age_group = st.selectbox(
+        "Alter des Kindes:",
+        ["< 3 Jahre", "3–6 Jahre", "7–9 Jahre", "10–12 Jahre", "13+ Jahre"],
+        key="age_group",
+    )
+    style = st.radio(
+        "Erklärform:",
+        ["normale Erklärung", "als Geschichte", "Frage-Antwort-Dialog"],
+        key="style",
+    )
+    length = st.radio(
+        "Umfang der Erklärung:", ["kurz", "mittel", "ausführlich"], key="length"
+    )
 
-    style = st.radio("Erklärform:",
-                     ["normale Erklärung", "als Geschichte", "Frage-Antwort-Dialog"])
+    if st.button("Erklärung generieren", key="explain_btn"):
+        explanation = generate_explanation(topic, age_group, style, length)
+        st.subheader("Kindgerechte Erklärung")
+        st.write(explanation)
 
-    length = st.radio("Umfang der Erklärung:",
-                      ["kurz", "mittel", "ausführlich"])
+        if st.button("🧘 Noch einfacher erklären", key="simpler_btn"):
+            simpler = generate_explanation(topic, age_group, style, "kurz")
+            st.subheader("Vereinfachte Erklärung")
+            st.write(simpler)
 
-    return topic, age_group, style, length
 
-def show_explanation(topic: str, age_group: str, style: str, length: str):
-    explanation = generate_explanation(topic, age_group, style, length)
-    st.subheader("Kindgerechte Erklärung")
-    st.write(explanation)
+def advice_tab():
+    """UI und Logik für die Eltern-Beratung."""
+    st.header("Eltern-Berater-Bot")
 
-    if st.button("🔁 Noch einfacher erklären"):
-        simpler = generate_explanation(topic, age_group, style, "kurz")
-        st.subheader("Vereinfachte Erklärung")
-        st.write(simpler)
+    question = st.text_input("Welche Erziehungsfrage hast du?", key="question")
+    child_age = st.number_input(
+        "Alter deines Kindes (in Jahren):", min_value=0, max_value=18, value=6, key="child_age"
+    )
+    parenting_style = st.selectbox(
+        "Bevorzugter Erziehungsstil:",
+        [
+            "Autoritär",
+            "Demokratisch",
+            "Laissez-Faire",
+            "Montessori",
+            "Situationsbedingt",
+            "Sonstige",
+        ],
+        key="parenting_style",
+    )
+
+    if st.button("Beratung erhalten", key="advice_btn"):
+        advice = generate_parenting_advice(question, child_age, parenting_style)
+        st.subheader("Beratung")
+        st.write(advice)
+
 
 def main():
-    topic, age_group, style, length = get_user_inputs()
+    st.set_page_config(page_title="Eltern-AI")
+    st.title("Eltern-AI")
 
-    if st.button("Erklärung generieren"):
-        show_explanation(topic, age_group, style, length)
+    tab_explain, tab_advice = st.tabs(["Erklärungs-Funktion", "Beratungs-Funktion"])
+
+    with tab_explain:
+        explanation_tab()
+
+    with tab_advice:
+        advice_tab()
+
 
 if __name__ == "__main__":
     main()

--- a/src/generate_advice.py
+++ b/src/generate_advice.py
@@ -1,0 +1,39 @@
+from openai import OpenAI
+from dotenv import load_dotenv
+import os
+
+# .env-Datei laden
+load_dotenv()
+
+# OpenAI-Client initialisieren
+api_key = os.getenv("OPENAI_API_KEY")
+client = OpenAI(api_key=api_key)
+
+
+def generate_parenting_advice(question: str, child_age: int, style: str) -> str:
+    """Erstellt eine Erziehungsberatung."""
+    system_msg = (
+        "Du bist eine erfahrene pädagogische Fachkraft und beantwortest einfühlsam "
+        "und fundiert Fragen zur Kindererziehung. Berücksichtige den angegebenen "
+        "Erziehungsstil und das Alter des Kindes."
+    )
+
+    user_prompt = (
+        f"Das Kind ist {child_age} Jahre alt und der bevorzugte Erziehungsstil ist '{style}'. "
+        f"Frage: {question}"
+    )
+
+    try:
+        response = client.chat.completions.create(
+            model="gpt-4",
+            messages=[
+                {"role": "system", "content": system_msg},
+                {"role": "user", "content": user_prompt},
+            ],
+            temperature=0.7,
+            max_tokens=800,
+        )
+        return response.choices[0].message.content.strip()
+
+    except Exception as e:
+        return f"❌ Fehler beim Abrufen der Beratung: {str(e)}"


### PR DESCRIPTION
## Summary
- implement neue LLM-Funktion `generate_parenting_advice`
- erweitere `app.py` um zwei Tabs: kindgerechte Erklärungen und Eltern-Beratung

## Testing
- `python -m py_compile app.py src/*.py`


------
https://chatgpt.com/codex/tasks/task_b_686fa5802894832f971e235b70746638