### PR TITLE
Support kids and adults in meal plans

### DIFF
--- a/app.py
+++ b/app.py
@@ -111,26 +111,32 @@ def meal_tab():
     """UI und Logik für Essensvorschläge."""
     st.header("Essensvorschläge")
 
-    age = st.number_input(
-        "Alter deines Kindes (in Jahren):",
+    child_count = st.number_input(
+        "Anzahl der Kinder:",
         min_value=0,
-        max_value=18,
-        value=6,
-        key="meal_age",
+        max_value=10,
+        value=1,
+        key="meal_child_count",
+    )
+
+    child_ages_input = st.text_input(
+        "Alter der Kinder (kommagetrennt):",
+        "6",
+        key="meal_child_ages",
+    )
+
+    adult_count = st.number_input(
+        "Anzahl der Erwachsenen:",
+        min_value=0,
+        max_value=10,
+        value=2,
+        key="meal_adults",
     )
 
     diet = st.selectbox(
         "Ernährungsstil:",
         ["Omnivor", "Vegetarisch", "Vegan", "Glutenfrei", "Laktosefrei", "Sonstige"],
         key="meal_diet",
-    )
-
-    portions = st.number_input(
-        "Anzahl der Portionen:",
-        min_value=1,
-        max_value=10,
-        value=2,
-        key="meal_portions",
     )
 
     foods_input = st.text_input(
@@ -140,7 +146,14 @@ def meal_tab():
 
     if st.button("Essensvorschlag generieren", key="meal_btn"):
         foods = [f.strip() for f in foods_input.split(",") if f.strip()] if foods_input else None
-        suggestion = generate_meal_suggestion(age, diet, portions, foods)
+        child_ages = [int(a.strip()) for a in child_ages_input.split(",") if a.strip()] if child_ages_input else []
+        # Wenn die Altersliste kürzer ist als die Kinderanzahl, fehlende Alter mit dem letzten Wert auffüllen
+        if child_ages and len(child_ages) < child_count:
+            child_ages.extend([child_ages[-1]] * (child_count - len(child_ages)))
+        elif not child_ages:
+            child_ages = [6] * child_count
+
+        suggestion = generate_meal_suggestion(child_ages[:child_count], adult_count, diet, foods)
         st.subheader("Vorgeschlagenes Gericht")
         st.write(suggestion)
 

--- a/src/generate_meal_suggestion.py
+++ b/src/generate_meal_suggestion.py
@@ -13,34 +13,40 @@ client = OpenAI(api_key=api_key)
 
 
 def generate_meal_suggestion(
-    age: int,
+    child_ages: List[int],
+    adult_count: int,
     diet: str,
-    portions: int,
     available_foods: Optional[List[str]] = None,
 ) -> str:
     """Generiert einen Essensvorschlag unter Berücksichtigung der Vorgaben.
 
-    :param age: Alter des Kindes in Jahren.
+    :param child_ages: Liste der Kinderalter in Jahren.
+    :param adult_count: Anzahl der Erwachsenen.
     :param diet: Ernährungsstil (z. B. "Vegetarisch").
-    :param portions: Anzahl der Portionen.
     :param available_foods: Liste vorhandener Lebensmittel.
     :return: Antworttext vom Sprachmodell.
     """
 
     available_text = (
-        f" Folgende Lebensmittel sind bereits vorhanden: {', '.join(available_foods)}." 
-        if available_foods else ""
+        f" Folgende Lebensmittel sind bereits vorhanden: {', '.join(available_foods)}."
+        if available_foods
+        else ""
     )
 
     system_msg = (
-        "Du bist ein erfahrener Koch, der gesunde Mahlzeiten für Kinder vorschlägt. "
-        "Berücksichtige Alter, Ernährungsstil und Portionsanzahl."
+        "Du bist ein erfahrener Koch, der gesunde Mahlzeiten für Familien vorschlägt. "
+        "Berücksichtige die Altersangaben der Kinder, die Anzahl der Erwachsenen und den Ernährungsstil."
     )
 
+    child_description = (
+        "keine Kinder"
+        if not child_ages
+        else f"{len(child_ages)} Kinder im Alter von {', '.join(map(str, child_ages))} Jahren"
+    )
     user_prompt = (
-        f"Das Kind ist {age} Jahre alt. "
+        f"Es sind {child_description} und {adult_count} Erwachsene zu verköstigen. "
         f"Der Ernährungsstil ist '{diet}'. "
-        f"Bitte schlage ein Gericht für {portions} Portionen vor." + available_text
+        "Bitte schlage ein Gericht mit passenden Portionen vor." + available_text
     )
 
     try:


### PR DESCRIPTION
## Summary
- add ability to set number of children and adults in meal suggestions
- adjust OpenAI prompt to consider children ages and adults

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686fc21a4e78832fbe25cf0fccbab1df